### PR TITLE
feat: apply fixes for preloading and later PHPUnit versions

### DIFF
--- a/scripts/compile.php
+++ b/scripts/compile.php
@@ -17,9 +17,14 @@ $remove = function ($contents, $string) {
 };
 
 $contents = file_get_contents($globalsFilePath);
-$contents = $replace($contents, 'namespace PHPUnit\Framework;', 'use PHPUnit\Framework\Assert;');
-$contents = $remove($contents, 'use function define;');
-$contents = $remove($contents, 'use function defined;');
+$contents = $replace($contents, 'namespace PHPUnit\Framework;', <<<'PHP'
+if (defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
+    return;
+}
+define('__PEST_GLOBAL_ASSERT_WRAPPERS__', true);
+
+use PHPUnit\Framework\Assert;
+PHP);
 $contents = $remove($contents, 'use function func_get_args;');
 $contents = $remove($contents, 'use ArrayAccess;');
 $contents = $remove($contents, 'use Countable;');
@@ -28,7 +33,6 @@ $contents = $remove($contents, 'use DOMElement;');
 $contents = $remove($contents, 'use Throwable;');
 
 // Fix for order of autoloading files
-$contents = $replace($contents, "if (!\\defined('__PHPUNIT_GLOBAL_ASSERT_WRAPPERS__')) {", "if (!\\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {");
-$contents = $replace($contents, "\\define('__PHPUNIT_GLOBAL_ASSERT_WRAPPERS__', true);\n}", "\\define('__PEST_GLOBAL_ASSERT_WRAPPERS__', true);\n}");
+$contents = $replace($contents, "if (!function_exists('PHPUnit\\Framework\\", "if (!function_exists('");
 
 file_put_contents($compiledFilePath, $contents);

--- a/src/compiled.php
+++ b/src/compiled.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 use PHPUnit\Framework\Assert;
+
 /*
  * This file is part of PHPUnit.
  *
@@ -10,6 +11,11 @@ use PHPUnit\Framework\Assert;
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+if (defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
+    return;
+}
+define('__PEST_GLOBAL_ASSERT_WRAPPERS__', true);
+
 use PHPUnit\Framework\Constraint\ArrayHasKey;
 use PHPUnit\Framework\Constraint\Callback;
 use PHPUnit\Framework\Constraint\ClassHasAttribute;
@@ -42,6 +48,7 @@ use PHPUnit\Framework\Constraint\LogicalAnd;
 use PHPUnit\Framework\Constraint\LogicalNot;
 use PHPUnit\Framework\Constraint\LogicalOr;
 use PHPUnit\Framework\Constraint\LogicalXor;
+use PHPUnit\Framework\Constraint\ObjectEquals;
 use PHPUnit\Framework\Constraint\ObjectHasAttribute;
 use PHPUnit\Framework\Constraint\RegularExpression;
 use PHPUnit\Framework\Constraint\StringContains;
@@ -66,7 +73,7 @@ use PHPUnit\Framework\MockObject\Stub\ReturnStub;
 use PHPUnit\Framework\MockObject\Stub\ReturnValueMap as ReturnValueMapStub;
 use SebastianBergmann\RecursionContext\InvalidArgumentException;
 
-if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
+if (!function_exists('assertArrayHasKey')) {
     /**
      * Asserts that an array has a specified key.
      *
@@ -77,13 +84,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws InvalidArgumentException
      * @throws Exception
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertArrayHasKey
      */
     function assertArrayHasKey($key, $array, string $message = ''): void
     {
-        Assert::assertArrayHasKey(...\func_get_args());
+        Assert::assertArrayHasKey(...func_get_args());
     }
+}
 
+if (!function_exists('assertArrayNotHasKey')) {
     /**
      * Asserts that an array does not have a specified key.
      *
@@ -94,13 +105,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws InvalidArgumentException
      * @throws Exception
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertArrayNotHasKey
      */
     function assertArrayNotHasKey($key, $array, string $message = ''): void
     {
-        Assert::assertArrayNotHasKey(...\func_get_args());
+        Assert::assertArrayNotHasKey(...func_get_args());
     }
+}
 
+if (!function_exists('assertContains')) {
     /**
      * Asserts that a haystack contains a needle.
      *
@@ -108,18 +123,24 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws InvalidArgumentException
      * @throws Exception
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertContains
      */
     function assertContains($needle, iterable $haystack, string $message = ''): void
     {
-        Assert::assertContains(...\func_get_args());
+        Assert::assertContains(...func_get_args());
     }
+}
 
+if (!function_exists('assertContainsEquals')) {
     function assertContainsEquals($needle, iterable $haystack, string $message = ''): void
     {
-        Assert::assertContainsEquals(...\func_get_args());
+        Assert::assertContainsEquals(...func_get_args());
     }
+}
 
+if (!function_exists('assertNotContains')) {
     /**
      * Asserts that a haystack does not contain a needle.
      *
@@ -127,57 +148,75 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws InvalidArgumentException
      * @throws Exception
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertNotContains
      */
     function assertNotContains($needle, iterable $haystack, string $message = ''): void
     {
-        Assert::assertNotContains(...\func_get_args());
+        Assert::assertNotContains(...func_get_args());
     }
+}
 
+if (!function_exists('assertNotContainsEquals')) {
     function assertNotContainsEquals($needle, iterable $haystack, string $message = ''): void
     {
-        Assert::assertNotContainsEquals(...\func_get_args());
+        Assert::assertNotContainsEquals(...func_get_args());
     }
+}
 
+if (!function_exists('assertContainsOnly')) {
     /**
      * Asserts that a haystack contains only values of a given type.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertContainsOnly
      */
     function assertContainsOnly(string $type, iterable $haystack, ?bool $isNativeType = null, string $message = ''): void
     {
-        Assert::assertContainsOnly(...\func_get_args());
+        Assert::assertContainsOnly(...func_get_args());
     }
+}
 
+if (!function_exists('assertContainsOnlyInstancesOf')) {
     /**
      * Asserts that a haystack contains only instances of a given class name.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertContainsOnlyInstancesOf
      */
     function assertContainsOnlyInstancesOf(string $className, iterable $haystack, string $message = ''): void
     {
-        Assert::assertContainsOnlyInstancesOf(...\func_get_args());
+        Assert::assertContainsOnlyInstancesOf(...func_get_args());
     }
+}
 
+if (!function_exists('assertNotContainsOnly')) {
     /**
      * Asserts that a haystack does not contain only values of a given type.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertNotContainsOnly
      */
     function assertNotContainsOnly(string $type, iterable $haystack, ?bool $isNativeType = null, string $message = ''): void
     {
-        Assert::assertNotContainsOnly(...\func_get_args());
+        Assert::assertNotContainsOnly(...func_get_args());
     }
+}
 
+if (!function_exists('assertCount')) {
     /**
      * Asserts the number of elements of an array, Countable or Traversable.
      *
@@ -186,14 +225,18 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      * @throws Exception
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
      *
      * @see Assert::assertCount
      */
     function assertCount(int $expectedCount, $haystack, string $message = ''): void
     {
-        Assert::assertCount(...\func_get_args());
+        Assert::assertCount(...func_get_args());
     }
+}
 
+if (!function_exists('assertNotCount')) {
     /**
      * Asserts the number of elements of an array, Countable or Traversable.
      *
@@ -203,117 +246,167 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws InvalidArgumentException
      * @throws Exception
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertNotCount
      */
     function assertNotCount(int $expectedCount, $haystack, string $message = ''): void
     {
-        Assert::assertNotCount(...\func_get_args());
+        Assert::assertNotCount(...func_get_args());
     }
+}
 
+if (!function_exists('assertEquals')) {
     /**
      * Asserts that two variables are equal.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertEquals
      */
     function assertEquals($expected, $actual, string $message = ''): void
     {
-        Assert::assertEquals(...\func_get_args());
+        Assert::assertEquals(...func_get_args());
     }
+}
 
+if (!function_exists('assertEqualsCanonicalizing')) {
     /**
      * Asserts that two variables are equal (canonicalizing).
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertEqualsCanonicalizing
      */
     function assertEqualsCanonicalizing($expected, $actual, string $message = ''): void
     {
-        Assert::assertEqualsCanonicalizing(...\func_get_args());
+        Assert::assertEqualsCanonicalizing(...func_get_args());
     }
+}
 
+if (!function_exists('assertEqualsIgnoringCase')) {
     /**
      * Asserts that two variables are equal (ignoring case).
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertEqualsIgnoringCase
      */
     function assertEqualsIgnoringCase($expected, $actual, string $message = ''): void
     {
-        Assert::assertEqualsIgnoringCase(...\func_get_args());
+        Assert::assertEqualsIgnoringCase(...func_get_args());
     }
+}
 
+if (!function_exists('assertEqualsWithDelta')) {
     /**
      * Asserts that two variables are equal (with delta).
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertEqualsWithDelta
      */
     function assertEqualsWithDelta($expected, $actual, float $delta, string $message = ''): void
     {
-        Assert::assertEqualsWithDelta(...\func_get_args());
+        Assert::assertEqualsWithDelta(...func_get_args());
     }
+}
 
+if (!function_exists('assertNotEquals')) {
     /**
      * Asserts that two variables are not equal.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertNotEquals
      */
     function assertNotEquals($expected, $actual, string $message = ''): void
     {
-        Assert::assertNotEquals(...\func_get_args());
+        Assert::assertNotEquals(...func_get_args());
     }
+}
 
+if (!function_exists('assertNotEqualsCanonicalizing')) {
     /**
      * Asserts that two variables are not equal (canonicalizing).
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertNotEqualsCanonicalizing
      */
     function assertNotEqualsCanonicalizing($expected, $actual, string $message = ''): void
     {
-        Assert::assertNotEqualsCanonicalizing(...\func_get_args());
+        Assert::assertNotEqualsCanonicalizing(...func_get_args());
     }
+}
 
+if (!function_exists('assertNotEqualsIgnoringCase')) {
     /**
      * Asserts that two variables are not equal (ignoring case).
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertNotEqualsIgnoringCase
      */
     function assertNotEqualsIgnoringCase($expected, $actual, string $message = ''): void
     {
-        Assert::assertNotEqualsIgnoringCase(...\func_get_args());
+        Assert::assertNotEqualsIgnoringCase(...func_get_args());
     }
+}
 
+if (!function_exists('assertNotEqualsWithDelta')) {
     /**
      * Asserts that two variables are not equal (with delta).
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertNotEqualsWithDelta
      */
     function assertNotEqualsWithDelta($expected, $actual, float $delta, string $message = ''): void
     {
-        Assert::assertNotEqualsWithDelta(...\func_get_args());
+        Assert::assertNotEqualsWithDelta(...func_get_args());
     }
+}
 
+if (!function_exists('assertObjectEquals')) {
+    /**
+     * @throws ExpectationFailedException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
+     * @see Assert::assertObjectEquals
+     */
+    function assertObjectEquals(object $expected, object $actual, string $method = 'equals', string $message = ''): void
+    {
+        Assert::assertObjectEquals(...func_get_args());
+    }
+}
+
+if (!function_exists('assertEmpty')) {
     /**
      * Asserts that a variable is empty.
      *
@@ -322,13 +415,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert empty $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertEmpty
      */
     function assertEmpty($actual, string $message = ''): void
     {
-        Assert::assertEmpty(...\func_get_args());
+        Assert::assertEmpty(...func_get_args());
     }
+}
 
+if (!function_exists('assertNotEmpty')) {
     /**
      * Asserts that a variable is not empty.
      *
@@ -337,65 +434,85 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert !empty $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertNotEmpty
      */
     function assertNotEmpty($actual, string $message = ''): void
     {
-        Assert::assertNotEmpty(...\func_get_args());
+        Assert::assertNotEmpty(...func_get_args());
     }
+}
 
+if (!function_exists('assertGreaterThan')) {
     /**
      * Asserts that a value is greater than another value.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertGreaterThan
      */
     function assertGreaterThan($expected, $actual, string $message = ''): void
     {
-        Assert::assertGreaterThan(...\func_get_args());
+        Assert::assertGreaterThan(...func_get_args());
     }
+}
 
+if (!function_exists('assertGreaterThanOrEqual')) {
     /**
      * Asserts that a value is greater than or equal to another value.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertGreaterThanOrEqual
      */
     function assertGreaterThanOrEqual($expected, $actual, string $message = ''): void
     {
-        Assert::assertGreaterThanOrEqual(...\func_get_args());
+        Assert::assertGreaterThanOrEqual(...func_get_args());
     }
+}
 
+if (!function_exists('assertLessThan')) {
     /**
      * Asserts that a value is smaller than another value.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertLessThan
      */
     function assertLessThan($expected, $actual, string $message = ''): void
     {
-        Assert::assertLessThan(...\func_get_args());
+        Assert::assertLessThan(...func_get_args());
     }
+}
 
+if (!function_exists('assertLessThanOrEqual')) {
     /**
      * Asserts that a value is smaller than or equal to another value.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertLessThanOrEqual
      */
     function assertLessThanOrEqual($expected, $actual, string $message = ''): void
     {
-        Assert::assertLessThanOrEqual(...\func_get_args());
+        Assert::assertLessThanOrEqual(...func_get_args());
     }
+}
 
+if (!function_exists('assertFileEquals')) {
     /**
      * Asserts that the contents of one file is equal to the contents of another
      * file.
@@ -403,13 +520,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertFileEquals
      */
     function assertFileEquals(string $expected, string $actual, string $message = ''): void
     {
-        Assert::assertFileEquals(...\func_get_args());
+        Assert::assertFileEquals(...func_get_args());
     }
+}
 
+if (!function_exists('assertFileEqualsCanonicalizing')) {
     /**
      * Asserts that the contents of one file is equal to the contents of another
      * file (canonicalizing).
@@ -417,13 +538,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertFileEqualsCanonicalizing
      */
     function assertFileEqualsCanonicalizing(string $expected, string $actual, string $message = ''): void
     {
-        Assert::assertFileEqualsCanonicalizing(...\func_get_args());
+        Assert::assertFileEqualsCanonicalizing(...func_get_args());
     }
+}
 
+if (!function_exists('assertFileEqualsIgnoringCase')) {
     /**
      * Asserts that the contents of one file is equal to the contents of another
      * file (ignoring case).
@@ -431,13 +556,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertFileEqualsIgnoringCase
      */
     function assertFileEqualsIgnoringCase(string $expected, string $actual, string $message = ''): void
     {
-        Assert::assertFileEqualsIgnoringCase(...\func_get_args());
+        Assert::assertFileEqualsIgnoringCase(...func_get_args());
     }
+}
 
+if (!function_exists('assertFileNotEquals')) {
     /**
      * Asserts that the contents of one file is not equal to the contents of
      * another file.
@@ -445,13 +574,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertFileNotEquals
      */
     function assertFileNotEquals(string $expected, string $actual, string $message = ''): void
     {
-        Assert::assertFileNotEquals(...\func_get_args());
+        Assert::assertFileNotEquals(...func_get_args());
     }
+}
 
+if (!function_exists('assertFileNotEqualsCanonicalizing')) {
     /**
      * Asserts that the contents of one file is not equal to the contents of another
      * file (canonicalizing).
@@ -459,13 +592,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertFileNotEqualsCanonicalizing
      */
     function assertFileNotEqualsCanonicalizing(string $expected, string $actual, string $message = ''): void
     {
-        Assert::assertFileNotEqualsCanonicalizing(...\func_get_args());
+        Assert::assertFileNotEqualsCanonicalizing(...func_get_args());
     }
+}
 
+if (!function_exists('assertFileNotEqualsIgnoringCase')) {
     /**
      * Asserts that the contents of one file is not equal to the contents of another
      * file (ignoring case).
@@ -473,27 +610,35 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertFileNotEqualsIgnoringCase
      */
     function assertFileNotEqualsIgnoringCase(string $expected, string $actual, string $message = ''): void
     {
-        Assert::assertFileNotEqualsIgnoringCase(...\func_get_args());
+        Assert::assertFileNotEqualsIgnoringCase(...func_get_args());
     }
+}
 
+if (!function_exists('assertStringEqualsFile')) {
     /**
      * Asserts that the contents of a string is equal
      * to the contents of a file.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
      *
      * @see Assert::assertStringEqualsFile
      */
     function assertStringEqualsFile(string $expectedFile, string $actualString, string $message = ''): void
     {
-        Assert::assertStringEqualsFile(...\func_get_args());
+        Assert::assertStringEqualsFile(...func_get_args());
     }
+}
 
+if (!function_exists('assertStringEqualsFileCanonicalizing')) {
     /**
      * Asserts that the contents of a string is equal
      * to the contents of a file (canonicalizing).
@@ -501,13 +646,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertStringEqualsFileCanonicalizing
      */
     function assertStringEqualsFileCanonicalizing(string $expectedFile, string $actualString, string $message = ''): void
     {
-        Assert::assertStringEqualsFileCanonicalizing(...\func_get_args());
+        Assert::assertStringEqualsFileCanonicalizing(...func_get_args());
     }
+}
 
+if (!function_exists('assertStringEqualsFileIgnoringCase')) {
     /**
      * Asserts that the contents of a string is equal
      * to the contents of a file (ignoring case).
@@ -515,13 +664,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertStringEqualsFileIgnoringCase
      */
     function assertStringEqualsFileIgnoringCase(string $expectedFile, string $actualString, string $message = ''): void
     {
-        Assert::assertStringEqualsFileIgnoringCase(...\func_get_args());
+        Assert::assertStringEqualsFileIgnoringCase(...func_get_args());
     }
+}
 
+if (!function_exists('assertStringNotEqualsFile')) {
     /**
      * Asserts that the contents of a string is not equal
      * to the contents of a file.
@@ -529,13 +682,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertStringNotEqualsFile
      */
     function assertStringNotEqualsFile(string $expectedFile, string $actualString, string $message = ''): void
     {
-        Assert::assertStringNotEqualsFile(...\func_get_args());
+        Assert::assertStringNotEqualsFile(...func_get_args());
     }
+}
 
+if (!function_exists('assertStringNotEqualsFileCanonicalizing')) {
     /**
      * Asserts that the contents of a string is not equal
      * to the contents of a file (canonicalizing).
@@ -543,13 +700,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertStringNotEqualsFileCanonicalizing
      */
     function assertStringNotEqualsFileCanonicalizing(string $expectedFile, string $actualString, string $message = ''): void
     {
-        Assert::assertStringNotEqualsFileCanonicalizing(...\func_get_args());
+        Assert::assertStringNotEqualsFileCanonicalizing(...func_get_args());
     }
+}
 
+if (!function_exists('assertStringNotEqualsFileIgnoringCase')) {
     /**
      * Asserts that the contents of a string is not equal
      * to the contents of a file (ignoring case).
@@ -557,39 +718,51 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertStringNotEqualsFileIgnoringCase
      */
     function assertStringNotEqualsFileIgnoringCase(string $expectedFile, string $actualString, string $message = ''): void
     {
-        Assert::assertStringNotEqualsFileIgnoringCase(...\func_get_args());
+        Assert::assertStringNotEqualsFileIgnoringCase(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsReadable')) {
     /**
      * Asserts that a file/dir is readable.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertIsReadable
      */
     function assertIsReadable(string $filename, string $message = ''): void
     {
-        Assert::assertIsReadable(...\func_get_args());
+        Assert::assertIsReadable(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsNotReadable')) {
     /**
      * Asserts that a file/dir exists and is not readable.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertIsNotReadable
      */
     function assertIsNotReadable(string $filename, string $message = ''): void
     {
-        Assert::assertIsNotReadable(...\func_get_args());
+        Assert::assertIsNotReadable(...func_get_args());
     }
+}
 
+if (!function_exists('assertNotIsReadable')) {
     /**
      * Asserts that a file/dir exists and is not readable.
      *
@@ -599,39 +772,52 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @codeCoverageIgnore
      *
      * @deprecated https://github.com/sebastianbergmann/phpunit/issues/4062
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertNotIsReadable
      */
     function assertNotIsReadable(string $filename, string $message = ''): void
     {
-        Assert::assertNotIsReadable(...\func_get_args());
+        Assert::assertNotIsReadable(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsWritable')) {
     /**
      * Asserts that a file/dir exists and is writable.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertIsWritable
      */
     function assertIsWritable(string $filename, string $message = ''): void
     {
-        Assert::assertIsWritable(...\func_get_args());
+        Assert::assertIsWritable(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsNotWritable')) {
     /**
      * Asserts that a file/dir exists and is not writable.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertIsNotWritable
      */
     function assertIsNotWritable(string $filename, string $message = ''): void
     {
-        Assert::assertIsNotWritable(...\func_get_args());
+        Assert::assertIsNotWritable(...func_get_args());
     }
+}
 
+if (!function_exists('assertNotIsWritable')) {
     /**
      * Asserts that a file/dir exists and is not writable.
      *
@@ -641,39 +827,52 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @codeCoverageIgnore
      *
      * @deprecated https://github.com/sebastianbergmann/phpunit/issues/4065
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertNotIsWritable
      */
     function assertNotIsWritable(string $filename, string $message = ''): void
     {
-        Assert::assertNotIsWritable(...\func_get_args());
+        Assert::assertNotIsWritable(...func_get_args());
     }
+}
 
+if (!function_exists('assertDirectoryExists')) {
     /**
      * Asserts that a directory exists.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertDirectoryExists
      */
     function assertDirectoryExists(string $directory, string $message = ''): void
     {
-        Assert::assertDirectoryExists(...\func_get_args());
+        Assert::assertDirectoryExists(...func_get_args());
     }
+}
 
+if (!function_exists('assertDirectoryDoesNotExist')) {
     /**
      * Asserts that a directory does not exist.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertDirectoryDoesNotExist
      */
     function assertDirectoryDoesNotExist(string $directory, string $message = ''): void
     {
-        Assert::assertDirectoryDoesNotExist(...\func_get_args());
+        Assert::assertDirectoryDoesNotExist(...func_get_args());
     }
+}
 
+if (!function_exists('assertDirectoryNotExists')) {
     /**
      * Asserts that a directory does not exist.
      *
@@ -683,39 +882,52 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @codeCoverageIgnore
      *
      * @deprecated https://github.com/sebastianbergmann/phpunit/issues/4068
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertDirectoryNotExists
      */
     function assertDirectoryNotExists(string $directory, string $message = ''): void
     {
-        Assert::assertDirectoryNotExists(...\func_get_args());
+        Assert::assertDirectoryNotExists(...func_get_args());
     }
+}
 
+if (!function_exists('assertDirectoryIsReadable')) {
     /**
      * Asserts that a directory exists and is readable.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertDirectoryIsReadable
      */
     function assertDirectoryIsReadable(string $directory, string $message = ''): void
     {
-        Assert::assertDirectoryIsReadable(...\func_get_args());
+        Assert::assertDirectoryIsReadable(...func_get_args());
     }
+}
 
+if (!function_exists('assertDirectoryIsNotReadable')) {
     /**
      * Asserts that a directory exists and is not readable.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertDirectoryIsNotReadable
      */
     function assertDirectoryIsNotReadable(string $directory, string $message = ''): void
     {
-        Assert::assertDirectoryIsNotReadable(...\func_get_args());
+        Assert::assertDirectoryIsNotReadable(...func_get_args());
     }
+}
 
+if (!function_exists('assertDirectoryNotIsReadable')) {
     /**
      * Asserts that a directory exists and is not readable.
      *
@@ -725,39 +937,52 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @codeCoverageIgnore
      *
      * @deprecated https://github.com/sebastianbergmann/phpunit/issues/4071
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertDirectoryNotIsReadable
      */
     function assertDirectoryNotIsReadable(string $directory, string $message = ''): void
     {
-        Assert::assertDirectoryNotIsReadable(...\func_get_args());
+        Assert::assertDirectoryNotIsReadable(...func_get_args());
     }
+}
 
+if (!function_exists('assertDirectoryIsWritable')) {
     /**
      * Asserts that a directory exists and is writable.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertDirectoryIsWritable
      */
     function assertDirectoryIsWritable(string $directory, string $message = ''): void
     {
-        Assert::assertDirectoryIsWritable(...\func_get_args());
+        Assert::assertDirectoryIsWritable(...func_get_args());
     }
+}
 
+if (!function_exists('assertDirectoryIsNotWritable')) {
     /**
      * Asserts that a directory exists and is not writable.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertDirectoryIsNotWritable
      */
     function assertDirectoryIsNotWritable(string $directory, string $message = ''): void
     {
-        Assert::assertDirectoryIsNotWritable(...\func_get_args());
+        Assert::assertDirectoryIsNotWritable(...func_get_args());
     }
+}
 
+if (!function_exists('assertDirectoryNotIsWritable')) {
     /**
      * Asserts that a directory exists and is not writable.
      *
@@ -767,39 +992,52 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @codeCoverageIgnore
      *
      * @deprecated https://github.com/sebastianbergmann/phpunit/issues/4074
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertDirectoryNotIsWritable
      */
     function assertDirectoryNotIsWritable(string $directory, string $message = ''): void
     {
-        Assert::assertDirectoryNotIsWritable(...\func_get_args());
+        Assert::assertDirectoryNotIsWritable(...func_get_args());
     }
+}
 
+if (!function_exists('assertFileExists')) {
     /**
      * Asserts that a file exists.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertFileExists
      */
     function assertFileExists(string $filename, string $message = ''): void
     {
-        Assert::assertFileExists(...\func_get_args());
+        Assert::assertFileExists(...func_get_args());
     }
+}
 
+if (!function_exists('assertFileDoesNotExist')) {
     /**
      * Asserts that a file does not exist.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertFileDoesNotExist
      */
     function assertFileDoesNotExist(string $filename, string $message = ''): void
     {
-        Assert::assertFileDoesNotExist(...\func_get_args());
+        Assert::assertFileDoesNotExist(...func_get_args());
     }
+}
 
+if (!function_exists('assertFileNotExists')) {
     /**
      * Asserts that a file does not exist.
      *
@@ -809,39 +1047,52 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @codeCoverageIgnore
      *
      * @deprecated https://github.com/sebastianbergmann/phpunit/issues/4077
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertFileNotExists
      */
     function assertFileNotExists(string $filename, string $message = ''): void
     {
-        Assert::assertFileNotExists(...\func_get_args());
+        Assert::assertFileNotExists(...func_get_args());
     }
+}
 
+if (!function_exists('assertFileIsReadable')) {
     /**
      * Asserts that a file exists and is readable.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertFileIsReadable
      */
     function assertFileIsReadable(string $file, string $message = ''): void
     {
-        Assert::assertFileIsReadable(...\func_get_args());
+        Assert::assertFileIsReadable(...func_get_args());
     }
+}
 
+if (!function_exists('assertFileIsNotReadable')) {
     /**
      * Asserts that a file exists and is not readable.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertFileIsNotReadable
      */
     function assertFileIsNotReadable(string $file, string $message = ''): void
     {
-        Assert::assertFileIsNotReadable(...\func_get_args());
+        Assert::assertFileIsNotReadable(...func_get_args());
     }
+}
 
+if (!function_exists('assertFileNotIsReadable')) {
     /**
      * Asserts that a file exists and is not readable.
      *
@@ -851,39 +1102,52 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @codeCoverageIgnore
      *
      * @deprecated https://github.com/sebastianbergmann/phpunit/issues/4080
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertFileNotIsReadable
      */
     function assertFileNotIsReadable(string $file, string $message = ''): void
     {
-        Assert::assertFileNotIsReadable(...\func_get_args());
+        Assert::assertFileNotIsReadable(...func_get_args());
     }
+}
 
+if (!function_exists('assertFileIsWritable')) {
     /**
      * Asserts that a file exists and is writable.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertFileIsWritable
      */
     function assertFileIsWritable(string $file, string $message = ''): void
     {
-        Assert::assertFileIsWritable(...\func_get_args());
+        Assert::assertFileIsWritable(...func_get_args());
     }
+}
 
+if (!function_exists('assertFileIsNotWritable')) {
     /**
      * Asserts that a file exists and is not writable.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertFileIsNotWritable
      */
     function assertFileIsNotWritable(string $file, string $message = ''): void
     {
-        Assert::assertFileIsNotWritable(...\func_get_args());
+        Assert::assertFileIsNotWritable(...func_get_args());
     }
+}
 
+if (!function_exists('assertFileNotIsWritable')) {
     /**
      * Asserts that a file exists and is not writable.
      *
@@ -893,13 +1157,18 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @codeCoverageIgnore
      *
      * @deprecated https://github.com/sebastianbergmann/phpunit/issues/4083
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertFileNotIsWritable
      */
     function assertFileNotIsWritable(string $file, string $message = ''): void
     {
-        Assert::assertFileNotIsWritable(...\func_get_args());
+        Assert::assertFileNotIsWritable(...func_get_args());
     }
+}
 
+if (!function_exists('assertTrue')) {
     /**
      * Asserts that a condition is true.
      *
@@ -908,13 +1177,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert true $condition
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertTrue
      */
     function assertTrue($condition, string $message = ''): void
     {
-        Assert::assertTrue(...\func_get_args());
+        Assert::assertTrue(...func_get_args());
     }
+}
 
+if (!function_exists('assertNotTrue')) {
     /**
      * Asserts that a condition is not true.
      *
@@ -923,13 +1196,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert !true $condition
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertNotTrue
      */
     function assertNotTrue($condition, string $message = ''): void
     {
-        Assert::assertNotTrue(...\func_get_args());
+        Assert::assertNotTrue(...func_get_args());
     }
+}
 
+if (!function_exists('assertFalse')) {
     /**
      * Asserts that a condition is false.
      *
@@ -938,13 +1215,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert false $condition
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertFalse
      */
     function assertFalse($condition, string $message = ''): void
     {
-        Assert::assertFalse(...\func_get_args());
+        Assert::assertFalse(...func_get_args());
     }
+}
 
+if (!function_exists('assertNotFalse')) {
     /**
      * Asserts that a condition is not false.
      *
@@ -953,13 +1234,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert !false $condition
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertNotFalse
      */
     function assertNotFalse($condition, string $message = ''): void
     {
-        Assert::assertNotFalse(...\func_get_args());
+        Assert::assertNotFalse(...func_get_args());
     }
+}
 
+if (!function_exists('assertNull')) {
     /**
      * Asserts that a variable is null.
      *
@@ -968,13 +1253,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert null $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertNull
      */
     function assertNull($actual, string $message = ''): void
     {
-        Assert::assertNull(...\func_get_args());
+        Assert::assertNull(...func_get_args());
     }
+}
 
+if (!function_exists('assertNotNull')) {
     /**
      * Asserts that a variable is not null.
      *
@@ -983,52 +1272,68 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert !null $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertNotNull
      */
     function assertNotNull($actual, string $message = ''): void
     {
-        Assert::assertNotNull(...\func_get_args());
+        Assert::assertNotNull(...func_get_args());
     }
+}
 
+if (!function_exists('assertFinite')) {
     /**
      * Asserts that a variable is finite.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertFinite
      */
     function assertFinite($actual, string $message = ''): void
     {
-        Assert::assertFinite(...\func_get_args());
+        Assert::assertFinite(...func_get_args());
     }
+}
 
+if (!function_exists('assertInfinite')) {
     /**
      * Asserts that a variable is infinite.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertInfinite
      */
     function assertInfinite($actual, string $message = ''): void
     {
-        Assert::assertInfinite(...\func_get_args());
+        Assert::assertInfinite(...func_get_args());
     }
+}
 
+if (!function_exists('assertNan')) {
     /**
      * Asserts that a variable is nan.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertNan
      */
     function assertNan($actual, string $message = ''): void
     {
-        Assert::assertNan(...\func_get_args());
+        Assert::assertNan(...func_get_args());
     }
+}
 
+if (!function_exists('assertClassHasAttribute')) {
     /**
      * Asserts that a class has a specified attribute.
      *
@@ -1036,13 +1341,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws InvalidArgumentException
      * @throws Exception
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertClassHasAttribute
      */
     function assertClassHasAttribute(string $attributeName, string $className, string $message = ''): void
     {
-        Assert::assertClassHasAttribute(...\func_get_args());
+        Assert::assertClassHasAttribute(...func_get_args());
     }
+}
 
+if (!function_exists('assertClassNotHasAttribute')) {
     /**
      * Asserts that a class does not have a specified attribute.
      *
@@ -1050,13 +1359,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws InvalidArgumentException
      * @throws Exception
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertClassNotHasAttribute
      */
     function assertClassNotHasAttribute(string $attributeName, string $className, string $message = ''): void
     {
-        Assert::assertClassNotHasAttribute(...\func_get_args());
+        Assert::assertClassNotHasAttribute(...func_get_args());
     }
+}
 
+if (!function_exists('assertClassHasStaticAttribute')) {
     /**
      * Asserts that a class has a specified static attribute.
      *
@@ -1064,13 +1377,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws InvalidArgumentException
      * @throws Exception
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertClassHasStaticAttribute
      */
     function assertClassHasStaticAttribute(string $attributeName, string $className, string $message = ''): void
     {
-        Assert::assertClassHasStaticAttribute(...\func_get_args());
+        Assert::assertClassHasStaticAttribute(...func_get_args());
     }
+}
 
+if (!function_exists('assertClassNotHasStaticAttribute')) {
     /**
      * Asserts that a class does not have a specified static attribute.
      *
@@ -1078,13 +1395,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws InvalidArgumentException
      * @throws Exception
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertClassNotHasStaticAttribute
      */
     function assertClassNotHasStaticAttribute(string $attributeName, string $className, string $message = ''): void
     {
-        Assert::assertClassNotHasStaticAttribute(...\func_get_args());
+        Assert::assertClassNotHasStaticAttribute(...func_get_args());
     }
+}
 
+if (!function_exists('assertObjectHasAttribute')) {
     /**
      * Asserts that an object has a specified attribute.
      *
@@ -1094,13 +1415,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws InvalidArgumentException
      * @throws Exception
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertObjectHasAttribute
      */
     function assertObjectHasAttribute(string $attributeName, $object, string $message = ''): void
     {
-        Assert::assertObjectHasAttribute(...\func_get_args());
+        Assert::assertObjectHasAttribute(...func_get_args());
     }
+}
 
+if (!function_exists('assertObjectNotHasAttribute')) {
     /**
      * Asserts that an object does not have a specified attribute.
      *
@@ -1110,13 +1435,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws InvalidArgumentException
      * @throws Exception
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertObjectNotHasAttribute
      */
     function assertObjectNotHasAttribute(string $attributeName, $object, string $message = ''): void
     {
-        Assert::assertObjectNotHasAttribute(...\func_get_args());
+        Assert::assertObjectNotHasAttribute(...func_get_args());
     }
+}
 
+if (!function_exists('assertSame')) {
     /**
      * Asserts that two variables have the same type and value.
      * Used on objects, it asserts that two variables reference
@@ -1129,13 +1458,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @psalm-param ExpectedType $expected
      * @psalm-assert =ExpectedType $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertSame
      */
     function assertSame($expected, $actual, string $message = ''): void
     {
-        Assert::assertSame(...\func_get_args());
+        Assert::assertSame(...func_get_args());
     }
+}
 
+if (!function_exists('assertNotSame')) {
     /**
      * Asserts that two variables do not have the same type and value.
      * Used on objects, it asserts that two variables do not reference
@@ -1144,13 +1477,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertNotSame
      */
     function assertNotSame($expected, $actual, string $message = ''): void
     {
-        Assert::assertNotSame(...\func_get_args());
+        Assert::assertNotSame(...func_get_args());
     }
+}
 
+if (!function_exists('assertInstanceOf')) {
     /**
      * Asserts that a variable is of a given type.
      *
@@ -1162,13 +1499,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @psalm-param class-string<ExpectedType> $expected
      * @psalm-assert ExpectedType $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertInstanceOf
      */
     function assertInstanceOf(string $expected, $actual, string $message = ''): void
     {
-        Assert::assertInstanceOf(...\func_get_args());
+        Assert::assertInstanceOf(...func_get_args());
     }
+}
 
+if (!function_exists('assertNotInstanceOf')) {
     /**
      * Asserts that a variable is not of a given type.
      *
@@ -1180,13 +1521,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @psalm-param class-string<ExpectedType> $expected
      * @psalm-assert !ExpectedType $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertNotInstanceOf
      */
     function assertNotInstanceOf(string $expected, $actual, string $message = ''): void
     {
-        Assert::assertNotInstanceOf(...\func_get_args());
+        Assert::assertNotInstanceOf(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsArray')) {
     /**
      * Asserts that a variable is of type array.
      *
@@ -1195,13 +1540,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert array $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertIsArray
      */
     function assertIsArray($actual, string $message = ''): void
     {
-        Assert::assertIsArray(...\func_get_args());
+        Assert::assertIsArray(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsBool')) {
     /**
      * Asserts that a variable is of type bool.
      *
@@ -1210,13 +1559,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert bool $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertIsBool
      */
     function assertIsBool($actual, string $message = ''): void
     {
-        Assert::assertIsBool(...\func_get_args());
+        Assert::assertIsBool(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsFloat')) {
     /**
      * Asserts that a variable is of type float.
      *
@@ -1225,13 +1578,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert float $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertIsFloat
      */
     function assertIsFloat($actual, string $message = ''): void
     {
-        Assert::assertIsFloat(...\func_get_args());
+        Assert::assertIsFloat(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsInt')) {
     /**
      * Asserts that a variable is of type int.
      *
@@ -1240,13 +1597,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert int $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertIsInt
      */
     function assertIsInt($actual, string $message = ''): void
     {
-        Assert::assertIsInt(...\func_get_args());
+        Assert::assertIsInt(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsNumeric')) {
     /**
      * Asserts that a variable is of type numeric.
      *
@@ -1255,13 +1616,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert numeric $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertIsNumeric
      */
     function assertIsNumeric($actual, string $message = ''): void
     {
-        Assert::assertIsNumeric(...\func_get_args());
+        Assert::assertIsNumeric(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsObject')) {
     /**
      * Asserts that a variable is of type object.
      *
@@ -1270,13 +1635,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert object $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertIsObject
      */
     function assertIsObject($actual, string $message = ''): void
     {
-        Assert::assertIsObject(...\func_get_args());
+        Assert::assertIsObject(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsResource')) {
     /**
      * Asserts that a variable is of type resource.
      *
@@ -1285,13 +1654,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert resource $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertIsResource
      */
     function assertIsResource($actual, string $message = ''): void
     {
-        Assert::assertIsResource(...\func_get_args());
+        Assert::assertIsResource(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsClosedResource')) {
     /**
      * Asserts that a variable is of type resource and is closed.
      *
@@ -1300,13 +1673,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert resource $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertIsClosedResource
      */
     function assertIsClosedResource($actual, string $message = ''): void
     {
-        Assert::assertIsClosedResource(...\func_get_args());
+        Assert::assertIsClosedResource(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsString')) {
     /**
      * Asserts that a variable is of type string.
      *
@@ -1315,13 +1692,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert string $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertIsString
      */
     function assertIsString($actual, string $message = ''): void
     {
-        Assert::assertIsString(...\func_get_args());
+        Assert::assertIsString(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsScalar')) {
     /**
      * Asserts that a variable is of type scalar.
      *
@@ -1330,13 +1711,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert scalar $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertIsScalar
      */
     function assertIsScalar($actual, string $message = ''): void
     {
-        Assert::assertIsScalar(...\func_get_args());
+        Assert::assertIsScalar(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsCallable')) {
     /**
      * Asserts that a variable is of type callable.
      *
@@ -1345,13 +1730,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert callable $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertIsCallable
      */
     function assertIsCallable($actual, string $message = ''): void
     {
-        Assert::assertIsCallable(...\func_get_args());
+        Assert::assertIsCallable(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsIterable')) {
     /**
      * Asserts that a variable is of type iterable.
      *
@@ -1360,13 +1749,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert iterable $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertIsIterable
      */
     function assertIsIterable($actual, string $message = ''): void
     {
-        Assert::assertIsIterable(...\func_get_args());
+        Assert::assertIsIterable(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsNotArray')) {
     /**
      * Asserts that a variable is not of type array.
      *
@@ -1375,13 +1768,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert !array $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertIsNotArray
      */
     function assertIsNotArray($actual, string $message = ''): void
     {
-        Assert::assertIsNotArray(...\func_get_args());
+        Assert::assertIsNotArray(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsNotBool')) {
     /**
      * Asserts that a variable is not of type bool.
      *
@@ -1390,13 +1787,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert !bool $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertIsNotBool
      */
     function assertIsNotBool($actual, string $message = ''): void
     {
-        Assert::assertIsNotBool(...\func_get_args());
+        Assert::assertIsNotBool(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsNotFloat')) {
     /**
      * Asserts that a variable is not of type float.
      *
@@ -1405,13 +1806,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert !float $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertIsNotFloat
      */
     function assertIsNotFloat($actual, string $message = ''): void
     {
-        Assert::assertIsNotFloat(...\func_get_args());
+        Assert::assertIsNotFloat(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsNotInt')) {
     /**
      * Asserts that a variable is not of type int.
      *
@@ -1420,13 +1825,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert !int $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertIsNotInt
      */
     function assertIsNotInt($actual, string $message = ''): void
     {
-        Assert::assertIsNotInt(...\func_get_args());
+        Assert::assertIsNotInt(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsNotNumeric')) {
     /**
      * Asserts that a variable is not of type numeric.
      *
@@ -1435,13 +1844,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert !numeric $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertIsNotNumeric
      */
     function assertIsNotNumeric($actual, string $message = ''): void
     {
-        Assert::assertIsNotNumeric(...\func_get_args());
+        Assert::assertIsNotNumeric(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsNotObject')) {
     /**
      * Asserts that a variable is not of type object.
      *
@@ -1450,13 +1863,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert !object $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertIsNotObject
      */
     function assertIsNotObject($actual, string $message = ''): void
     {
-        Assert::assertIsNotObject(...\func_get_args());
+        Assert::assertIsNotObject(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsNotResource')) {
     /**
      * Asserts that a variable is not of type resource.
      *
@@ -1464,14 +1881,18 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws InvalidArgumentException
      *
      * @psalm-assert !resource $actual
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
      *
      * @see Assert::assertIsNotResource
      */
     function assertIsNotResource($actual, string $message = ''): void
     {
-        Assert::assertIsNotResource(...\func_get_args());
+        Assert::assertIsNotResource(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsNotClosedResource')) {
     /**
      * Asserts that a variable is not of type resource.
      *
@@ -1480,13 +1901,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert !resource $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertIsNotClosedResource
      */
     function assertIsNotClosedResource($actual, string $message = ''): void
     {
-        Assert::assertIsNotClosedResource(...\func_get_args());
+        Assert::assertIsNotClosedResource(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsNotString')) {
     /**
      * Asserts that a variable is not of type string.
      *
@@ -1495,13 +1920,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert !string $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertIsNotString
      */
     function assertIsNotString($actual, string $message = ''): void
     {
-        Assert::assertIsNotString(...\func_get_args());
+        Assert::assertIsNotString(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsNotScalar')) {
     /**
      * Asserts that a variable is not of type scalar.
      *
@@ -1510,13 +1939,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert !scalar $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertIsNotScalar
      */
     function assertIsNotScalar($actual, string $message = ''): void
     {
-        Assert::assertIsNotScalar(...\func_get_args());
+        Assert::assertIsNotScalar(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsNotCallable')) {
     /**
      * Asserts that a variable is not of type callable.
      *
@@ -1525,13 +1958,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert !callable $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertIsNotCallable
      */
     function assertIsNotCallable($actual, string $message = ''): void
     {
-        Assert::assertIsNotCallable(...\func_get_args());
+        Assert::assertIsNotCallable(...func_get_args());
     }
+}
 
+if (!function_exists('assertIsNotIterable')) {
     /**
      * Asserts that a variable is not of type iterable.
      *
@@ -1540,26 +1977,34 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      *
      * @psalm-assert !iterable $actual
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertIsNotIterable
      */
     function assertIsNotIterable($actual, string $message = ''): void
     {
-        Assert::assertIsNotIterable(...\func_get_args());
+        Assert::assertIsNotIterable(...func_get_args());
     }
+}
 
+if (!function_exists('assertMatchesRegularExpression')) {
     /**
      * Asserts that a string matches a given regular expression.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertMatchesRegularExpression
      */
     function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
     {
-        Assert::assertMatchesRegularExpression(...\func_get_args());
+        Assert::assertMatchesRegularExpression(...func_get_args());
     }
+}
 
+if (!function_exists('assertRegExp')) {
     /**
      * Asserts that a string matches a given regular expression.
      *
@@ -1569,26 +2014,35 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @codeCoverageIgnore
      *
      * @deprecated https://github.com/sebastianbergmann/phpunit/issues/4086
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertRegExp
      */
     function assertRegExp(string $pattern, string $string, string $message = ''): void
     {
-        Assert::assertRegExp(...\func_get_args());
+        Assert::assertRegExp(...func_get_args());
     }
+}
 
+if (!function_exists('assertDoesNotMatchRegularExpression')) {
     /**
      * Asserts that a string does not match a given regular expression.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertDoesNotMatchRegularExpression
      */
     function assertDoesNotMatchRegularExpression(string $pattern, string $string, string $message = ''): void
     {
-        Assert::assertDoesNotMatchRegularExpression(...\func_get_args());
+        Assert::assertDoesNotMatchRegularExpression(...func_get_args());
     }
+}
 
+if (!function_exists('assertNotRegExp')) {
     /**
      * Asserts that a string does not match a given regular expression.
      *
@@ -1598,13 +2052,18 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @codeCoverageIgnore
      *
      * @deprecated https://github.com/sebastianbergmann/phpunit/issues/4089
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertNotRegExp
      */
     function assertNotRegExp(string $pattern, string $string, string $message = ''): void
     {
-        Assert::assertNotRegExp(...\func_get_args());
+        Assert::assertNotRegExp(...func_get_args());
     }
+}
 
+if (!function_exists('assertSameSize')) {
     /**
      * Assert that the size of two arrays (or `Countable` or `Traversable` objects)
      * is the same.
@@ -1616,13 +2075,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws InvalidArgumentException
      * @throws Exception
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertSameSize
      */
     function assertSameSize($expected, $actual, string $message = ''): void
     {
-        Assert::assertSameSize(...\func_get_args());
+        Assert::assertSameSize(...func_get_args());
     }
+}
 
+if (!function_exists('assertNotSameSize')) {
     /**
      * Assert that the size of two arrays (or `Countable` or `Traversable` objects)
      * is not the same.
@@ -1634,78 +2097,102 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws InvalidArgumentException
      * @throws Exception
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertNotSameSize
      */
     function assertNotSameSize($expected, $actual, string $message = ''): void
     {
-        Assert::assertNotSameSize(...\func_get_args());
+        Assert::assertNotSameSize(...func_get_args());
     }
+}
 
+if (!function_exists('assertStringMatchesFormat')) {
     /**
      * Asserts that a string matches a given format string.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertStringMatchesFormat
      */
     function assertStringMatchesFormat(string $format, string $string, string $message = ''): void
     {
-        Assert::assertStringMatchesFormat(...\func_get_args());
+        Assert::assertStringMatchesFormat(...func_get_args());
     }
+}
 
+if (!function_exists('assertStringNotMatchesFormat')) {
     /**
      * Asserts that a string does not match a given format string.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertStringNotMatchesFormat
      */
     function assertStringNotMatchesFormat(string $format, string $string, string $message = ''): void
     {
-        Assert::assertStringNotMatchesFormat(...\func_get_args());
+        Assert::assertStringNotMatchesFormat(...func_get_args());
     }
+}
 
+if (!function_exists('assertStringMatchesFormatFile')) {
     /**
      * Asserts that a string matches a given format file.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertStringMatchesFormatFile
      */
     function assertStringMatchesFormatFile(string $formatFile, string $string, string $message = ''): void
     {
-        Assert::assertStringMatchesFormatFile(...\func_get_args());
+        Assert::assertStringMatchesFormatFile(...func_get_args());
     }
+}
 
+if (!function_exists('assertStringNotMatchesFormatFile')) {
     /**
      * Asserts that a string does not match a given format string.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertStringNotMatchesFormatFile
      */
     function assertStringNotMatchesFormatFile(string $formatFile, string $string, string $message = ''): void
     {
-        Assert::assertStringNotMatchesFormatFile(...\func_get_args());
+        Assert::assertStringNotMatchesFormatFile(...func_get_args());
     }
+}
 
+if (!function_exists('assertStringStartsWith')) {
     /**
      * Asserts that a string starts with a given prefix.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertStringStartsWith
      */
     function assertStringStartsWith(string $prefix, string $string, string $message = ''): void
     {
-        Assert::assertStringStartsWith(...\func_get_args());
+        Assert::assertStringStartsWith(...func_get_args());
     }
+}
 
+if (!function_exists('assertStringStartsNotWith')) {
     /**
      * Asserts that a string starts not with a given prefix.
      *
@@ -1715,83 +2202,111 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertStringStartsNotWith
      */
     function assertStringStartsNotWith($prefix, $string, string $message = ''): void
     {
-        Assert::assertStringStartsNotWith(...\func_get_args());
+        Assert::assertStringStartsNotWith(...func_get_args());
     }
+}
 
+if (!function_exists('assertStringContainsString')) {
     /**
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
      *
      * @see Assert::assertStringContainsString
      */
     function assertStringContainsString(string $needle, string $haystack, string $message = ''): void
     {
-        Assert::assertStringContainsString(...\func_get_args());
+        Assert::assertStringContainsString(...func_get_args());
     }
+}
 
+if (!function_exists('assertStringContainsStringIgnoringCase')) {
     /**
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
      *
      * @see Assert::assertStringContainsStringIgnoringCase
      */
     function assertStringContainsStringIgnoringCase(string $needle, string $haystack, string $message = ''): void
     {
-        Assert::assertStringContainsStringIgnoringCase(...\func_get_args());
+        Assert::assertStringContainsStringIgnoringCase(...func_get_args());
     }
+}
 
+if (!function_exists('assertStringNotContainsString')) {
     /**
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
      *
      * @see Assert::assertStringNotContainsString
      */
     function assertStringNotContainsString(string $needle, string $haystack, string $message = ''): void
     {
-        Assert::assertStringNotContainsString(...\func_get_args());
+        Assert::assertStringNotContainsString(...func_get_args());
     }
+}
 
+if (!function_exists('assertStringNotContainsStringIgnoringCase')) {
     /**
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
      *
      * @see Assert::assertStringNotContainsStringIgnoringCase
      */
     function assertStringNotContainsStringIgnoringCase(string $needle, string $haystack, string $message = ''): void
     {
-        Assert::assertStringNotContainsStringIgnoringCase(...\func_get_args());
+        Assert::assertStringNotContainsStringIgnoringCase(...func_get_args());
     }
+}
 
+if (!function_exists('assertStringEndsWith')) {
     /**
      * Asserts that a string ends with a given suffix.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertStringEndsWith
      */
     function assertStringEndsWith(string $suffix, string $string, string $message = ''): void
     {
-        Assert::assertStringEndsWith(...\func_get_args());
+        Assert::assertStringEndsWith(...func_get_args());
     }
+}
 
+if (!function_exists('assertStringEndsNotWith')) {
     /**
      * Asserts that a string ends not with a given suffix.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertStringEndsNotWith
      */
     function assertStringEndsNotWith(string $suffix, string $string, string $message = ''): void
     {
-        Assert::assertStringEndsNotWith(...\func_get_args());
+        Assert::assertStringEndsNotWith(...func_get_args());
     }
+}
 
+if (!function_exists('assertXmlFileEqualsXmlFile')) {
     /**
      * Asserts that two XML files are equal.
      *
@@ -1799,13 +2314,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws InvalidArgumentException
      * @throws Exception
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertXmlFileEqualsXmlFile
      */
     function assertXmlFileEqualsXmlFile(string $expectedFile, string $actualFile, string $message = ''): void
     {
-        Assert::assertXmlFileEqualsXmlFile(...\func_get_args());
+        Assert::assertXmlFileEqualsXmlFile(...func_get_args());
     }
+}
 
+if (!function_exists('assertXmlFileNotEqualsXmlFile')) {
     /**
      * Asserts that two XML files are not equal.
      *
@@ -1813,13 +2332,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws InvalidArgumentException
      * @throws \PHPUnit\Util\Exception
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertXmlFileNotEqualsXmlFile
      */
     function assertXmlFileNotEqualsXmlFile(string $expectedFile, string $actualFile, string $message = ''): void
     {
-        Assert::assertXmlFileNotEqualsXmlFile(...\func_get_args());
+        Assert::assertXmlFileNotEqualsXmlFile(...func_get_args());
     }
+}
 
+if (!function_exists('assertXmlStringEqualsXmlFile')) {
     /**
      * Asserts that two XML documents are equal.
      *
@@ -1828,14 +2351,18 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      * @throws \PHPUnit\Util\Xml\Exception
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
      *
      * @see Assert::assertXmlStringEqualsXmlFile
      */
     function assertXmlStringEqualsXmlFile(string $expectedFile, $actualXml, string $message = ''): void
     {
-        Assert::assertXmlStringEqualsXmlFile(...\func_get_args());
+        Assert::assertXmlStringEqualsXmlFile(...func_get_args());
     }
+}
 
+if (!function_exists('assertXmlStringNotEqualsXmlFile')) {
     /**
      * Asserts that two XML documents are not equal.
      *
@@ -1845,13 +2372,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws InvalidArgumentException
      * @throws \PHPUnit\Util\Xml\Exception
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertXmlStringNotEqualsXmlFile
      */
     function assertXmlStringNotEqualsXmlFile(string $expectedFile, $actualXml, string $message = ''): void
     {
-        Assert::assertXmlStringNotEqualsXmlFile(...\func_get_args());
+        Assert::assertXmlStringNotEqualsXmlFile(...func_get_args());
     }
+}
 
+if (!function_exists('assertXmlStringEqualsXmlString')) {
     /**
      * Asserts that two XML documents are equal.
      *
@@ -1862,13 +2393,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws InvalidArgumentException
      * @throws \PHPUnit\Util\Xml\Exception
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertXmlStringEqualsXmlString
      */
     function assertXmlStringEqualsXmlString($expectedXml, $actualXml, string $message = ''): void
     {
-        Assert::assertXmlStringEqualsXmlString(...\func_get_args());
+        Assert::assertXmlStringEqualsXmlString(...func_get_args());
     }
+}
 
+if (!function_exists('assertXmlStringNotEqualsXmlString')) {
     /**
      * Asserts that two XML documents are not equal.
      *
@@ -1879,13 +2414,17 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws InvalidArgumentException
      * @throws \PHPUnit\Util\Xml\Exception
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertXmlStringNotEqualsXmlString
      */
     function assertXmlStringNotEqualsXmlString($expectedXml, $actualXml, string $message = ''): void
     {
-        Assert::assertXmlStringNotEqualsXmlString(...\func_get_args());
+        Assert::assertXmlStringNotEqualsXmlString(...func_get_args());
     }
+}
 
+if (!function_exists('assertEqualXMLStructure')) {
     /**
      * Asserts that a hierarchy of DOMElements matches.
      *
@@ -1896,52 +2435,69 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @codeCoverageIgnore
      *
      * @deprecated https://github.com/sebastianbergmann/phpunit/issues/4091
+     *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertEqualXMLStructure
      */
     function assertEqualXMLStructure(DOMElement $expectedElement, DOMElement $actualElement, bool $checkAttributes = false, string $message = ''): void
     {
-        Assert::assertEqualXMLStructure(...\func_get_args());
+        Assert::assertEqualXMLStructure(...func_get_args());
     }
+}
 
+if (!function_exists('assertThat')) {
     /**
      * Evaluates a PHPUnit\Framework\Constraint matcher object.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertThat
      */
     function assertThat($value, Constraint $constraint, string $message = ''): void
     {
-        Assert::assertThat(...\func_get_args());
+        Assert::assertThat(...func_get_args());
     }
+}
 
+if (!function_exists('assertJson')) {
     /**
      * Asserts that a string is a valid JSON string.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertJson
      */
     function assertJson(string $actualJson, string $message = ''): void
     {
-        Assert::assertJson(...\func_get_args());
+        Assert::assertJson(...func_get_args());
     }
+}
 
+if (!function_exists('assertJsonStringEqualsJsonString')) {
     /**
      * Asserts that two given JSON encoded objects or arrays are equal.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertJsonStringEqualsJsonString
      */
     function assertJsonStringEqualsJsonString(string $expectedJson, string $actualJson, string $message = ''): void
     {
-        Assert::assertJsonStringEqualsJsonString(...\func_get_args());
+        Assert::assertJsonStringEqualsJsonString(...func_get_args());
     }
+}
 
+if (!function_exists('assertJsonStringNotEqualsJsonString')) {
     /**
      * Asserts that two given JSON encoded objects or arrays are not equal.
      *
@@ -1951,280 +2507,393 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertJsonStringNotEqualsJsonString
      */
     function assertJsonStringNotEqualsJsonString($expectedJson, $actualJson, string $message = ''): void
     {
-        Assert::assertJsonStringNotEqualsJsonString(...\func_get_args());
+        Assert::assertJsonStringNotEqualsJsonString(...func_get_args());
     }
+}
 
+if (!function_exists('assertJsonStringEqualsJsonFile')) {
     /**
      * Asserts that the generated JSON encoded object and the content of the given file are equal.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertJsonStringEqualsJsonFile
      */
     function assertJsonStringEqualsJsonFile(string $expectedFile, string $actualJson, string $message = ''): void
     {
-        Assert::assertJsonStringEqualsJsonFile(...\func_get_args());
+        Assert::assertJsonStringEqualsJsonFile(...func_get_args());
     }
+}
 
+if (!function_exists('assertJsonStringNotEqualsJsonFile')) {
     /**
      * Asserts that the generated JSON encoded object and the content of the given file are not equal.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertJsonStringNotEqualsJsonFile
      */
     function assertJsonStringNotEqualsJsonFile(string $expectedFile, string $actualJson, string $message = ''): void
     {
-        Assert::assertJsonStringNotEqualsJsonFile(...\func_get_args());
+        Assert::assertJsonStringNotEqualsJsonFile(...func_get_args());
     }
+}
 
+if (!function_exists('assertJsonFileEqualsJsonFile')) {
     /**
      * Asserts that two JSON files are equal.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertJsonFileEqualsJsonFile
      */
     function assertJsonFileEqualsJsonFile(string $expectedFile, string $actualFile, string $message = ''): void
     {
-        Assert::assertJsonFileEqualsJsonFile(...\func_get_args());
+        Assert::assertJsonFileEqualsJsonFile(...func_get_args());
     }
+}
 
+if (!function_exists('assertJsonFileNotEqualsJsonFile')) {
     /**
      * Asserts that two JSON files are not equal.
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      *
+     * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
+     *
      * @see Assert::assertJsonFileNotEqualsJsonFile
      */
     function assertJsonFileNotEqualsJsonFile(string $expectedFile, string $actualFile, string $message = ''): void
     {
-        Assert::assertJsonFileNotEqualsJsonFile(...\func_get_args());
+        Assert::assertJsonFileNotEqualsJsonFile(...func_get_args());
     }
+}
 
+if (!function_exists('logicalAnd')) {
     function logicalAnd(): LogicalAnd
     {
-        return Assert::logicalAnd(...\func_get_args());
+        return Assert::logicalAnd(...func_get_args());
     }
+}
 
+if (!function_exists('logicalOr')) {
     function logicalOr(): LogicalOr
     {
-        return Assert::logicalOr(...\func_get_args());
+        return Assert::logicalOr(...func_get_args());
     }
+}
 
+if (!function_exists('logicalNot')) {
     function logicalNot(Constraint $constraint): LogicalNot
     {
-        return Assert::logicalNot(...\func_get_args());
+        return Assert::logicalNot(...func_get_args());
     }
+}
 
+if (!function_exists('logicalXor')) {
     function logicalXor(): LogicalXor
     {
-        return Assert::logicalXor(...\func_get_args());
+        return Assert::logicalXor(...func_get_args());
     }
+}
 
+if (!function_exists('anything')) {
     function anything(): IsAnything
     {
-        return Assert::anything(...\func_get_args());
+        return Assert::anything(...func_get_args());
     }
+}
 
+if (!function_exists('isTrue')) {
     function isTrue(): IsTrue
     {
-        return Assert::isTrue(...\func_get_args());
+        return Assert::isTrue(...func_get_args());
     }
+}
 
+if (!function_exists('callback')) {
     function callback(callable $callback): Callback
     {
-        return Assert::callback(...\func_get_args());
+        return Assert::callback(...func_get_args());
     }
+}
 
+if (!function_exists('isFalse')) {
     function isFalse(): IsFalse
     {
-        return Assert::isFalse(...\func_get_args());
+        return Assert::isFalse(...func_get_args());
     }
+}
 
+if (!function_exists('isJson')) {
     function isJson(): IsJson
     {
-        return Assert::isJson(...\func_get_args());
+        return Assert::isJson(...func_get_args());
     }
+}
 
+if (!function_exists('isNull')) {
     function isNull(): IsNull
     {
-        return Assert::isNull(...\func_get_args());
+        return Assert::isNull(...func_get_args());
     }
+}
 
+if (!function_exists('isFinite')) {
     function isFinite(): IsFinite
     {
-        return Assert::isFinite(...\func_get_args());
+        return Assert::isFinite(...func_get_args());
     }
+}
 
+if (!function_exists('isInfinite')) {
     function isInfinite(): IsInfinite
     {
-        return Assert::isInfinite(...\func_get_args());
+        return Assert::isInfinite(...func_get_args());
     }
+}
 
+if (!function_exists('isNan')) {
     function isNan(): IsNan
     {
-        return Assert::isNan(...\func_get_args());
+        return Assert::isNan(...func_get_args());
     }
+}
 
+if (!function_exists('containsEqual')) {
     function containsEqual($value): TraversableContainsEqual
     {
-        return Assert::containsEqual(...\func_get_args());
+        return Assert::containsEqual(...func_get_args());
     }
+}
 
+if (!function_exists('containsIdentical')) {
     function containsIdentical($value): TraversableContainsIdentical
     {
-        return Assert::containsIdentical(...\func_get_args());
+        return Assert::containsIdentical(...func_get_args());
     }
+}
 
+if (!function_exists('containsOnly')) {
     function containsOnly(string $type): TraversableContainsOnly
     {
-        return Assert::containsOnly(...\func_get_args());
+        return Assert::containsOnly(...func_get_args());
     }
+}
 
+if (!function_exists('containsOnlyInstancesOf')) {
     function containsOnlyInstancesOf(string $className): TraversableContainsOnly
     {
-        return Assert::containsOnlyInstancesOf(...\func_get_args());
+        return Assert::containsOnlyInstancesOf(...func_get_args());
     }
+}
 
+if (!function_exists('arrayHasKey')) {
     function arrayHasKey($key): ArrayHasKey
     {
-        return Assert::arrayHasKey(...\func_get_args());
+        return Assert::arrayHasKey(...func_get_args());
     }
+}
 
+if (!function_exists('equalTo')) {
     function equalTo($value): IsEqual
     {
-        return Assert::equalTo(...\func_get_args());
+        return Assert::equalTo(...func_get_args());
     }
+}
 
+if (!function_exists('equalToCanonicalizing')) {
     function equalToCanonicalizing($value): IsEqualCanonicalizing
     {
-        return Assert::equalToCanonicalizing(...\func_get_args());
+        return Assert::equalToCanonicalizing(...func_get_args());
     }
+}
 
+if (!function_exists('equalToIgnoringCase')) {
     function equalToIgnoringCase($value): IsEqualIgnoringCase
     {
-        return Assert::equalToIgnoringCase(...\func_get_args());
+        return Assert::equalToIgnoringCase(...func_get_args());
     }
+}
 
+if (!function_exists('equalToWithDelta')) {
     function equalToWithDelta($value, float $delta): IsEqualWithDelta
     {
-        return Assert::equalToWithDelta(...\func_get_args());
+        return Assert::equalToWithDelta(...func_get_args());
     }
+}
 
+if (!function_exists('isEmpty')) {
     function isEmpty(): IsEmpty
     {
-        return Assert::isEmpty(...\func_get_args());
+        return Assert::isEmpty(...func_get_args());
     }
+}
 
+if (!function_exists('isWritable')) {
     function isWritable(): IsWritable
     {
-        return Assert::isWritable(...\func_get_args());
+        return Assert::isWritable(...func_get_args());
     }
+}
 
+if (!function_exists('isReadable')) {
     function isReadable(): IsReadable
     {
-        return Assert::isReadable(...\func_get_args());
+        return Assert::isReadable(...func_get_args());
     }
+}
 
+if (!function_exists('directoryExists')) {
     function directoryExists(): DirectoryExists
     {
-        return Assert::directoryExists(...\func_get_args());
+        return Assert::directoryExists(...func_get_args());
     }
+}
 
+if (!function_exists('fileExists')) {
     function fileExists(): FileExists
     {
-        return Assert::fileExists(...\func_get_args());
+        return Assert::fileExists(...func_get_args());
     }
+}
 
+if (!function_exists('greaterThan')) {
     function greaterThan($value): GreaterThan
     {
-        return Assert::greaterThan(...\func_get_args());
+        return Assert::greaterThan(...func_get_args());
     }
+}
 
+if (!function_exists('greaterThanOrEqual')) {
     function greaterThanOrEqual($value): LogicalOr
     {
-        return Assert::greaterThanOrEqual(...\func_get_args());
+        return Assert::greaterThanOrEqual(...func_get_args());
     }
+}
 
+if (!function_exists('classHasAttribute')) {
     function classHasAttribute(string $attributeName): ClassHasAttribute
     {
-        return Assert::classHasAttribute(...\func_get_args());
+        return Assert::classHasAttribute(...func_get_args());
     }
+}
 
+if (!function_exists('classHasStaticAttribute')) {
     function classHasStaticAttribute(string $attributeName): ClassHasStaticAttribute
     {
-        return Assert::classHasStaticAttribute(...\func_get_args());
+        return Assert::classHasStaticAttribute(...func_get_args());
     }
+}
 
+if (!function_exists('objectHasAttribute')) {
     function objectHasAttribute($attributeName): ObjectHasAttribute
     {
-        return Assert::objectHasAttribute(...\func_get_args());
+        return Assert::objectHasAttribute(...func_get_args());
     }
+}
 
+if (!function_exists('identicalTo')) {
     function identicalTo($value): IsIdentical
     {
-        return Assert::identicalTo(...\func_get_args());
+        return Assert::identicalTo(...func_get_args());
     }
+}
 
+if (!function_exists('isInstanceOf')) {
     function isInstanceOf(string $className): IsInstanceOf
     {
-        return Assert::isInstanceOf(...\func_get_args());
+        return Assert::isInstanceOf(...func_get_args());
     }
+}
 
+if (!function_exists('isType')) {
     function isType(string $type): IsType
     {
-        return Assert::isType(...\func_get_args());
+        return Assert::isType(...func_get_args());
     }
+}
 
+if (!function_exists('lessThan')) {
     function lessThan($value): LessThan
     {
-        return Assert::lessThan(...\func_get_args());
+        return Assert::lessThan(...func_get_args());
     }
+}
 
+if (!function_exists('lessThanOrEqual')) {
     function lessThanOrEqual($value): LogicalOr
     {
-        return Assert::lessThanOrEqual(...\func_get_args());
+        return Assert::lessThanOrEqual(...func_get_args());
     }
+}
 
+if (!function_exists('matchesRegularExpression')) {
     function matchesRegularExpression(string $pattern): RegularExpression
     {
-        return Assert::matchesRegularExpression(...\func_get_args());
+        return Assert::matchesRegularExpression(...func_get_args());
     }
+}
 
+if (!function_exists('matches')) {
     function matches(string $string): StringMatchesFormatDescription
     {
-        return Assert::matches(...\func_get_args());
+        return Assert::matches(...func_get_args());
     }
+}
 
+if (!function_exists('stringStartsWith')) {
     function stringStartsWith($prefix): StringStartsWith
     {
-        return Assert::stringStartsWith(...\func_get_args());
+        return Assert::stringStartsWith(...func_get_args());
     }
+}
 
+if (!function_exists('stringContains')) {
     function stringContains(string $string, bool $case = true): StringContains
     {
-        return Assert::stringContains(...\func_get_args());
+        return Assert::stringContains(...func_get_args());
     }
+}
 
+if (!function_exists('stringEndsWith')) {
     function stringEndsWith(string $suffix): StringEndsWith
     {
-        return Assert::stringEndsWith(...\func_get_args());
+        return Assert::stringEndsWith(...func_get_args());
     }
+}
 
+if (!function_exists('countOf')) {
     function countOf(int $count): Count
     {
-        return Assert::countOf(...\func_get_args());
+        return Assert::countOf(...func_get_args());
     }
+}
 
+if (!function_exists('objectEquals')) {
+    function objectEquals(object $object, string $method = 'equals'): ObjectEquals
+    {
+        return Assert::objectEquals(...func_get_args());
+    }
+}
+
+if (!function_exists('any')) {
     /**
      * Returns a matcher that matches when the method is executed
      * zero or more times.
@@ -2233,7 +2902,9 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
     {
         return new AnyInvokedCountMatcher();
     }
+}
 
+if (!function_exists('never')) {
     /**
      * Returns a matcher that matches when the method is never executed.
      */
@@ -2241,7 +2912,9 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
     {
         return new InvokedCountMatcher(0);
     }
+}
 
+if (!function_exists('atLeast')) {
     /**
      * Returns a matcher that matches when the method is executed
      * at least N times.
@@ -2252,7 +2925,9 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
             $requiredInvocations
         );
     }
+}
 
+if (!function_exists('atLeastOnce')) {
     /**
      * Returns a matcher that matches when the method is executed at least once.
      */
@@ -2260,7 +2935,9 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
     {
         return new InvokedAtLeastOnceMatcher();
     }
+}
 
+if (!function_exists('once')) {
     /**
      * Returns a matcher that matches when the method is executed exactly once.
      */
@@ -2268,7 +2945,9 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
     {
         return new InvokedCountMatcher(1);
     }
+}
 
+if (!function_exists('exactly')) {
     /**
      * Returns a matcher that matches when the method is executed
      * exactly $count times.
@@ -2277,7 +2956,9 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
     {
         return new InvokedCountMatcher($count);
     }
+}
 
+if (!function_exists('atMost')) {
     /**
      * Returns a matcher that matches when the method is executed
      * at most N times.
@@ -2286,7 +2967,9 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
     {
         return new InvokedAtMostCountMatcher($allowedInvocations);
     }
+}
 
+if (!function_exists('at')) {
     /**
      * Returns a matcher that matches when the method is executed
      * at the given index.
@@ -2295,27 +2978,37 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
     {
         return new InvokedAtIndexMatcher($index);
     }
+}
 
+if (!function_exists('returnValue')) {
     function returnValue($value): ReturnStub
     {
         return new ReturnStub($value);
     }
+}
 
+if (!function_exists('returnValueMap')) {
     function returnValueMap(array $valueMap): ReturnValueMapStub
     {
         return new ReturnValueMapStub($valueMap);
     }
+}
 
+if (!function_exists('returnArgument')) {
     function returnArgument(int $argumentIndex): ReturnArgumentStub
     {
         return new ReturnArgumentStub($argumentIndex);
     }
+}
 
+if (!function_exists('returnCallback')) {
     function returnCallback($callback): ReturnCallbackStub
     {
         return new ReturnCallbackStub($callback);
     }
+}
 
+if (!function_exists('returnSelf')) {
     /**
      * Returns the current object.
      *
@@ -2325,18 +3018,20 @@ if (!\defined('__PEST_GLOBAL_ASSERT_WRAPPERS__')) {
     {
         return new ReturnSelfStub();
     }
+}
 
+if (!function_exists('throwException')) {
     function throwException(Throwable $exception): ExceptionStub
     {
         return new ExceptionStub($exception);
     }
+}
 
+if (!function_exists('onConsecutiveCalls')) {
     function onConsecutiveCalls(): ConsecutiveCallsStub
     {
-        $args = \func_get_args();
+        $args = func_get_args();
 
         return new ConsecutiveCallsStub($args);
     }
-
-    \define('__PEST_GLOBAL_ASSERT_WRAPPERS__', true);
 }

--- a/tests/Functions.php
+++ b/tests/Functions.php
@@ -5,3 +5,8 @@ declare(strict_types=1);
 it('adds global assertions', function (): void {
     assertTrue(true);
 });
+
+it('defines constant for global assertions', function (): void {
+    assertTrue(defined('__PEST_GLOBAL_ASSERT_WRAPPERS__'));
+    assertEquals(true, __PEST_GLOBAL_ASSERT_WRAPPERS__);
+});


### PR DESCRIPTION
This applies the changes that were added in PHPUnit 9.3.8 to resolve issues in https://github.com/sebastianbergmann/phpunit/issues/4435.

Each function is now checked to see whether it is already defined, which should allow preloading. I've also kept the `__PEST_GLOBAL_ASSERT_WRAPPERS__` constant incase anyone was using it for some reason. 🤷🏻